### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Heru Handika <herubiolog@gmail.com>"]
 license = "MIT"
 description = "A high-performance, accessible phylogenomic pipeline"
 readme = "README.md"
-homepage = "https://github.com/hhandika/ullar"
+repository = "https://github.com/hhandika/ullar"
 keywords = ["cli", "utility", "pipeline", "genomics", "phylogenomics"]
 categories = ["command-line-utilities", "science"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.